### PR TITLE
Prevent exception for non-latin(cyrillic) method names.

### DIFF
--- a/soapclient.js
+++ b/soapclient.js
@@ -176,7 +176,7 @@ SOAPClient._sendSoapRequest = function(url, method, parameters, async, callback,
 	}
 	else
 		xmlHttp.open("POST", url, async);
-	var soapaction = ((ns.lastIndexOf("/") != ns.length - 1) ? ns + "/" : ns) + method;
+	var soapaction = ((ns.lastIndexOf("/") != ns.length - 1) ? ns + "/" : ns) + encodeURIComponent(method);
 	xmlHttp.setRequestHeader("SOAPAction", soapaction);
 	xmlHttp.setRequestHeader("Content-Type", "text/xml; charset=utf-8");
 	if(async) 


### PR DESCRIPTION
Hi! Here's the cleaner version of that fix you've closed. Once again, sorry for that mess.