### PR TITLE
fix Uncaught TypeError: Cannot read property 'constructor' of null

### DIFF
--- a/angular.soap.js
+++ b/angular.soap.js
@@ -13,7 +13,7 @@ angular.module('angularSoap', [])
 			
 			//Create Callback
 			var soapCallback = function(e){
-				if(e.constructor.toString().indexOf("function Error()") != -1){
+				if(e && e.constructor.toString().indexOf("function Error()") != -1){
 					deferred.reject("An error has occurred.");
 				} else {
 					deferred.resolve(e);


### PR DESCRIPTION
When a void response is given from the SOAP service, the e parameter of the soapCallback is null.

This should solve issues #24, #17. Possibly #12 but an example there suggests assume failure rather than assume success.
